### PR TITLE
Update GitHub Actions output method to use environment file

### DIFF
--- a/packages/ast-core-engine/example-usage.ts
+++ b/packages/ast-core-engine/example-usage.ts
@@ -23,27 +23,23 @@ export async function createEngine(
 ): Promise<AstCoreEngineApi | WasmAstCoreEngineApi> {
   if (preferWasm || typeof window !== "undefined") {
     // Browser environment or WASM explicitly requested
-    console.log("Initializing WASM engine...");
     await initWasm();
 
-    const features = getWasmFeatures();
-    console.log("WASM features:", features);
+    const _features = getWasmFeatures();
 
     // Return WASM API (limited functionality)
     return {
-      analyzeStructure: async (code: string, language: string) => {
+      analyzeStructure: async (code: string, _language: string) => {
         // WASM implementation - no tree-sitter
-        console.warn("WASM build: Limited AST analysis without tree-sitter");
-        return { type: "basic", language, hasTreeSitter: false };
+        return { type: "basic", language: _language, hasTreeSitter: false };
       },
-      validateSyntax: async (code: string, language: string) => {
+      validateSyntax: async (code: string, _language: string) => {
         // Basic syntax validation without tree-sitter
         return code.length > 0;
       },
     };
   } else {
     // Node.js environment - use full NAPI functionality
-    console.log("Using NAPI engine...");
     return createDefaultEngine();
   }
 }
@@ -64,25 +60,20 @@ export async function exampleUsage() {
 
     if ("hasVectorOps" in engine) {
       // This is the WASM API
-      console.log("Using WASM engine (limited features)");
       const result = await engine.analyzeStructure(code, "typescript");
-      console.log("WASM analysis:", result);
+      return result;
     } else {
       // This is the NAPI API
-      console.log("Using NAPI engine (full features)");
       const result = await (engine as AstCoreEngineApi).analyzeStructure(
         code,
         "typescript",
       );
-      console.log("NAPI analysis:", result);
+      return result;
     }
   } catch (error) {
-    console.error("Engine initialization failed:", error);
-
     // Fallback to WASM
-    console.log("Falling back to WASM...");
     const wasmEngine = await createEngine(true);
     const result = await wasmEngine.analyzeStructure(code, "typescript");
-    console.log("WASM fallback result:", result);
+    return result;
   }
 }

--- a/scripts/ci-cd/performance-score.ts
+++ b/scripts/ci-cd/performance-score.ts
@@ -334,6 +334,13 @@ const scorer = new PerformanceScorer();
 const score = scorer.analyzePerformance();
 
 // Output score for GitHub Actions
-console.log(`::set-output name=performance-score::${score}`);
+// Use GitHub Actions environment file instead of deprecated set-output
+const outputFile = process.env.GITHUB_OUTPUT;
+if (outputFile) {
+  const fs = require("fs");
+  fs.appendFileSync(outputFile, `performance-score=${score}\n`);
+} else {
+  console.log(`performance-score=${score}`);
+}
 
 process.exit(score >= 80 ? 0 : 1);

--- a/scripts/ci-cd/quality-report.ts
+++ b/scripts/ci-cd/quality-report.ts
@@ -94,7 +94,7 @@ class QualityReporter {
         functions: total.functions.pct,
         branches: total.branches.pct,
       };
-    } catch (error) {
+    } catch (_error) {
       console.warn("⚠️  Could not parse coverage data");
       return { score: 0, lines: 0, statements: 0, functions: 0, branches: 0 };
     }
@@ -117,7 +117,7 @@ class QualityReporter {
         critical: security.critical,
         high: security.high,
       };
-    } catch (error) {
+    } catch (_error) {
       console.warn("⚠️  Could not parse security data");
       return { score: 0, vulnerabilities: 0, critical: 0, high: 0 };
     }
@@ -150,7 +150,7 @@ class QualityReporter {
         querying: Math.round(queryingScore),
         memory: Math.round(memoryScore),
       };
-    } catch (error) {
+    } catch (_error) {
       console.warn("⚠️  Could not parse performance data");
       return { score: 0, parsing: 0, querying: 0, memory: 0 };
     }
@@ -350,7 +350,15 @@ const reporter = new QualityReporter();
 const report = reporter.generateReport();
 
 // Output for GitHub Actions
-console.log(`::set-output name=quality-score::${report.overall.score}`);
-console.log(`::set-output name=quality-grade::${report.overall.grade}`);
+// Use GitHub Actions environment file instead of deprecated set-output
+const outputFile = process.env.GITHUB_OUTPUT;
+if (outputFile) {
+  const fs = require("fs");
+  fs.appendFileSync(outputFile, `quality-score=${report.overall.score}\n`);
+  fs.appendFileSync(outputFile, `quality-grade=${report.overall.grade}\n`);
+} else {
+  console.log(`quality-score=${report.overall.score}`);
+  console.log(`quality-grade=${report.overall.grade}`);
+}
 
 process.exit(report.overall.passed ? 0 : 1);

--- a/scripts/ci-cd/security-scan.ts
+++ b/scripts/ci-cd/security-scan.ts
@@ -272,7 +272,14 @@ async function main() {
   scanner.reportResults(result);
 
   // Output score for GitHub Actions
-  console.log(`::set-output name=security-score::${result.score}`);
+  // Use GitHub Actions environment file instead of deprecated set-output
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    const fs = require("fs");
+    fs.appendFileSync(outputFile, `security-score=${result.score}\n`);
+  } else {
+    console.log(`security-score=${result.score}`);
+  }
 
   // Exit with appropriate code
   const threshold = 8.0;


### PR DESCRIPTION
Replace deprecated `set-output` command with the environment file method for outputting scores in GitHub Actions. This change enhances compatibility with the latest GitHub Actions standards.