### PR TITLE
Specify shell for binary builds and enhance Dockerfile for Rust and wasm-pack

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -267,6 +267,7 @@ jobs:
           yarn build
 
       - name: Build binary for ${{ matrix.platform }}
+        shell: bash
         run: |
           echo "🔨 Building binary for ${{ matrix.platform }}"
           echo "Platform: ${{ matrix.platform }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,18 @@ FROM node:20-alpine AS builder
 # Set working directory
 WORKDIR /app
 
-# Install dependencies for building native modules
-RUN apk add --no-cache python3 make g++
+# Install dependencies for building native modules and Rust
+RUN apk add --no-cache python3 make g++ curl
+
+# Install Rust and Cargo
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install wasm-pack for WebAssembly builds
+RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# Verify Rust installation
+RUN rustc --version && cargo --version
 
 # Copy package files for dependency installation
 COPY package.json yarn.lock .yarnrc.yml ./


### PR DESCRIPTION
Specify the shell for building binaries in the release pipeline and enhance the Dockerfile to include installation of Rust and wasm-pack for WebAssembly support.