### PR TITLE
Improve readability of console.warn in database reader test

### DIFF
--- a/tests/unit/mcp/database-reader.test.ts
+++ b/tests/unit/mcp/database-reader.test.ts
@@ -131,7 +131,10 @@ describe("ASTDatabaseReader", () => {
           continue;
         }
         // If it's not a busy error or we've exhausted retries, log and continue
-        console.warn(`Failed to cleanup temp directory after ${attempts + 1} attempts:`, error.message);
+        console.warn(
+          `Failed to cleanup temp directory after ${attempts + 1} attempts:`,
+          error.message,
+        );
         break;
       }
     }


### PR DESCRIPTION
Format the console.warn statement for better line wrapping and apply Prettier for consistent code style.